### PR TITLE
Fixes issue #190

### DIFF
--- a/db/seed/full/dagi/opstillingskreds/2_type.sql
+++ b/db/seed/full/dagi/opstillingskreds/2_type.sql
@@ -3,11 +3,11 @@ CREATE SCHEMA IF NOT EXISTS api;
 DROP TYPE IF EXISTS api.opstillingskreds CASCADE;
 
 CREATE TYPE api.opstillingskreds AS (
-    opstillingskredsnummer text,
+    opstillingskredsnummer int,
     opstillingskredsnavn text,
     visningstekst text,
-    valgkredsnummer text,
-    storkredsnummer text,
+    valgkredsnummer int,
+    storkredsnummer int,
     storkredsnavn text,
     kommunekode text,
     geometri geometry,

--- a/db/seed/full/dagi/opstillingskreds/9_function.sql
+++ b/db/seed/full/dagi/opstillingskreds/9_function.sql
@@ -49,11 +49,11 @@ BEGIN
         tokens INTO plain_query_string;
     -- Execute and return the result
     stmt = format(E'SELECT
-                opstillingskredsnummer::text,
+                opstillingskredsnummer::int,
                 opstillingskredsnavn::text,
                 visningstekst,
-                valgkredsnummer::text,
-                storkredsnummer::text,
+                valgkredsnummer::int,
+                storkredsnummer::int,
                 storkredsnavn::text,
                 kommunekode::text,
                 geometri,

--- a/db/seed/full/dagi/politikreds/2_type.sql
+++ b/db/seed/full/dagi/politikreds/2_type.sql
@@ -3,7 +3,7 @@ CREATE SCHEMA IF NOT EXISTS api;
 DROP TYPE IF EXISTS api.politikreds CASCADE;
 
 CREATE TYPE api.politikreds AS (
-    politikredsnummer text,
+    politikredsnummer int,
     navn text,
     visningstekst text,
     myndighedskode text,

--- a/db/seed/full/dagi/politikreds/9_function.sql
+++ b/db/seed/full/dagi/politikreds/9_function.sql
@@ -48,7 +48,7 @@ BEGIN
         tokens INTO plain_query_string;
     -- Execute and return the result
     stmt = format(E'SELECT
-            politikredsnummer::text,
+            politikredsnummer::int,
             navn::text,
             visningstekst,
             myndighedskode::text,

--- a/db/seed/full/dagi/retskreds/2_type.sql
+++ b/db/seed/full/dagi/retskreds/2_type.sql
@@ -3,7 +3,7 @@ CREATE SCHEMA IF NOT EXISTS api;
 DROP TYPE IF EXISTS api.retskreds CASCADE;
 
 CREATE TYPE api.retskreds AS (
-    retskredsnummer text,
+    retskredsnummer int,
     retkredsnavn text,
     visningstekst text,
     myndighedskode text,

--- a/db/seed/full/dagi/retskreds/9_function.sql
+++ b/db/seed/full/dagi/retskreds/9_function.sql
@@ -48,7 +48,7 @@ BEGIN
         tokens INTO plain_query_string;
     -- Execute and return the result
     stmt = format(E'SELECT
-                retskredsnummer::text,
+                retskredsnummer::int,
                 retkredsnavn::text,
                 visningstekst::text,
                 myndighedskode::text,

--- a/db/seed/full/matriklen/2_type.sql
+++ b/db/seed/full/matriklen/2_type.sql
@@ -4,15 +4,15 @@ DROP TYPE IF EXISTS api.matrikel CASCADE;
 
 CREATE TYPE api.matrikel AS (
     ejerlavsnavn text,
-    ejerlavskode text,
+    ejerlavskode int,
     kommunenavn text,
     kommunekode text,
     matrikelnummer text,
     visningstekst text,
-    jordstykke_id text,
-    bfenummer text,
-    centroid_x text,
-    centroid_y text,
+    jordstykke_id int,
+    bfenummer int,
+    centroid_x numeric,
+    centroid_y numeric,
     geometri geometry
     );
 

--- a/db/seed/full/matriklen/2_type.sql
+++ b/db/seed/full/matriklen/2_type.sql
@@ -28,14 +28,14 @@ COMMENT ON COLUMN api.matrikel.kommunekode IS 'Kommunekode(r) for kommune(r) der
 
 COMMENT ON COLUMN api.matrikel.matrikelnummer IS 'Matrikelnummer';
 
-COMMENT ON COLUMN api.matrikel.visningstekst IS 'Præsentationsform for et matrikelnummer';
+COMMENT ON COLUMN api.matrikel.visningstekst IS 'Præsentationsform for et matrikel';
 
 COMMENT ON COLUMN api.matrikel.jordstykke_id IS 'Jordstykke lokalid';
 
-COMMENT ON COLUMN api.matrikel.bfenummer IS 'BFE-nummer for matriklen';
+COMMENT ON COLUMN api.matrikel.bfenummer IS 'BFE-nummer for matrikel';
 
 COMMENT ON COLUMN api.matrikel.centroid_x IS 'Centroide X for matriklens geometri';
 
 COMMENT ON COLUMN api.matrikel.centroid_y IS 'Centroide Y for matriklens geometri';
 
-COMMENT ON COLUMN api.matrikel.geometri IS 'Geometri i EPSG:25832';
+COMMENT ON COLUMN api.matrikel.geometri IS 'Geometri i EPSG:25832 for matrikel';

--- a/db/seed/full/matriklen/9_function.sql
+++ b/db/seed/full/matriklen/9_function.sql
@@ -69,15 +69,15 @@ BEGIN
     THEN
         stmt = format(E'SELECT
                 ejerlavsnavn::text,
-                ejerlavskode::text,
+                ejerlavskode::int,
                 kommunenavn::text,
                 kommunekode::text,
                 matrikelnummer::text,
                 visningstekst::text,
-                jordstykke_id::text,
-                bfenummer::text,
-                ST_X((ST_DUMP(centroide_geometri)).geom)::text,
-                ST_Y((ST_DUMP(centroide_geometri)).geom)::text,
+                jordstykke_id::int,
+                bfenummer::int,
+                ST_X((ST_DUMP(centroide_geometri)).geom)::numeric,
+                ST_Y((ST_DUMP(centroide_geometri)).geom)::numeric,
                 geometri
             FROM
                 basic.matrikel
@@ -92,15 +92,15 @@ BEGIN
         -- Execute and return the result
         stmt = format(E'SELECT
                 ejerlavsnavn::text,
-                ejerlavskode::text,
+                ejerlavskode::int,
                 kommunenavn::text,
                 kommunekode::text,
                 matrikelnummer::text,
                 visningstekst::text,
-                jordstykke_id::text,
-                bfenummer::text,
-                ST_X((ST_DUMP(centroide_geometri)).geom)::text,
-                ST_Y((ST_DUMP(centroide_geometri)).geom)::text,
+                jordstykke_id::int,
+                bfenummer::int,
+                ST_X((ST_DUMP(centroide_geometri)).geom)::numeric,
+                ST_Y((ST_DUMP(centroide_geometri)).geom)::numeric,
                 geometri
             FROM
                 basic.matrikel

--- a/db/seed/full/matriklen_udgaaet/2_type.sql
+++ b/db/seed/full/matriklen_udgaaet/2_type.sql
@@ -4,15 +4,15 @@ DROP TYPE IF EXISTS api.matrikel_udgaaet CASCADE;
 
 CREATE TYPE api.matrikel_udgaaet AS (
     ejerlavsnavn text,
-    ejerlavskode text,
+    ejerlavskode int,
     kommunenavn text,
     kommunekode text,
     matrikelnummer text,
     visningstekst text,
-    jordstykke_id text,
-    bfenummer text,
-    centroid_x text,
-    centroid_y text,
+    jordstykke_id int,
+    bfenummer int,
+    centroid_x numeric,
+    centroid_y numeric,
     geometri geometry
 );
 

--- a/db/seed/full/matriklen_udgaaet/2_type.sql
+++ b/db/seed/full/matriklen_udgaaet/2_type.sql
@@ -16,26 +16,26 @@ CREATE TYPE api.matrikel_udgaaet AS (
     geometri geometry
 );
 
-COMMENT ON TYPE api.matrikel_udgaaet IS 'Matrikelnummer';
+COMMENT ON TYPE api.matrikel_udgaaet IS 'Matrikelnummer udgået';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.ejerlavsnavn IS 'Ejerlavsnavn for matrikel';
+COMMENT ON COLUMN api.matrikel_udgaaet.ejerlavsnavn IS 'Ejerlavsnavn for udgået matrikel';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.ejerlavskode IS 'Ejerlavskode for matrikel';
+COMMENT ON COLUMN api.matrikel_udgaaet.ejerlavskode IS 'Ejerlavskode for udgået matrikel';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.kommunenavn IS 'Kommunenavn for matrikel';
+COMMENT ON COLUMN api.matrikel_udgaaet.kommunenavn IS 'Kommunenavn for udgået matrikel';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.kommunekode IS 'Kommunekode(r) for kommune(r) der ligger i eller optil matrikel';
+COMMENT ON COLUMN api.matrikel_udgaaet.kommunekode IS 'Kommunekode(r) for kommune(r) der ligger i eller optil udgået matrikel';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.matrikelnummer IS 'Matrikelnummer';
+COMMENT ON COLUMN api.matrikel_udgaaet.matrikelnummer IS 'Matrikelnummer udgået';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.visningstekst IS 'Præsentationsform for et matrikelnummer';
+COMMENT ON COLUMN api.matrikel_udgaaet.visningstekst IS 'Præsentationsform for et udgået matrikel';
 
-COMMENT ON COLUMN api.matrikel.jordstykke_id IS 'Jordstykke lokalid';
+COMMENT ON COLUMN api.matrikel.jordstykke_id IS 'Jordstykke lokalid for udgået matrikel';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.bfenummer IS 'BFE-nummer for matriklen';
+COMMENT ON COLUMN api.matrikel_udgaaet.bfenummer IS 'BFE-nummer for udgået matrikl';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.centroid_x IS 'Centroide X for matriklens geometri';
+COMMENT ON COLUMN api.matrikel_udgaaet.centroid_x IS 'Centroide X for udgået matriklens geometri';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.centroid_y IS 'Centroide Y for matriklens geometri';
+COMMENT ON COLUMN api.matrikel_udgaaet.centroid_y IS 'Centroide Y for udgået matriklens geometri';
 
-COMMENT ON COLUMN api.matrikel_udgaaet.geometri IS 'Geometri i EPSG:25832';
+COMMENT ON COLUMN api.matrikel_udgaaet.geometri IS 'Geometri i EPSG:25832 for udgået matrikel';

--- a/db/seed/full/matriklen_udgaaet/9_function.sql
+++ b/db/seed/full/matriklen_udgaaet/9_function.sql
@@ -72,15 +72,15 @@ BEGIN
     THEN
         stmt = format(E'SELECT
                 ejerlavsnavn::text,
-                ejerlavskode::text,
+                ejerlavskode::int,
                 kommunenavn::text,
                 kommunekode::text,
                 matrikelnummer::text,
                 visningstekst::text,
-                jordstykke_id::text,
-                bfenummer::text,
-                ST_X((ST_DUMP(centroide_geometri)).geom)::text,
-                ST_Y((ST_DUMP(centroide_geometri)).geom)::text,
+                jordstykke_id::int,
+                bfenummer::int,
+                ST_X((ST_DUMP(centroide_geometri)).geom)::numeric,
+                ST_Y((ST_DUMP(centroide_geometri)).geom)::numeric,
                 geometri
             FROM
                 basic.matrikel_udgaaet
@@ -95,15 +95,15 @@ BEGIN
         -- Execute and return the result
         stmt = format(E'SELECT
                 ejerlavsnavn::text,
-                ejerlavskode::text,
+                ejerlavskode::int,
                 kommunenavn::text,
                 kommunekode::text,
                 matrikelnummer::text,
                 visningstekst::text,
-                jordstykke_id::text,
-                bfenummer::text,
-                ST_X((ST_DUMP(centroide_geometri)).geom)::text,
-                ST_Y((ST_DUMP(centroide_geometri)).geom)::text,
+                jordstykke_id::int,
+                bfenummer::int,
+                ST_X((ST_DUMP(centroide_geometri)).geom)::numeric,
+                ST_Y((ST_DUMP(centroide_geometri)).geom)::numeric,
                 geometri
             FROM
                 basic.matrikel_udgaaet

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -123,8 +123,23 @@ public class DataMapper implements RowMapper<Object> {
 
     private matrikel mapMatrikel(ResultSet rs, StatementContext ctx) throws SQLException {
         matrikel data = new matrikel();
+        // Return strings as numbers
+        List<String> intColumns  = new ArrayList<String>(4);
+        intColumns.add("ejerlavskode");
+        intColumns.add("jordstykke_id");
+        intColumns.add("bfenummer");
+
         for (int i = 1; i <= meta.getColumnCount(); i++)
-            data.add(meta.getColumnName(i), mapColumn(i, rs));
+            if (intColumns.contains(meta.getColumnName(i))) {
+                data.add(meta.getColumnName(i), rs.getInt(i));
+            }
+            else if (columnName.equals("centroid_x") || columnName.equals("centroid_y")) {
+                data.add(meta.getColumnName(i), rs.getFloat(i));
+            }
+            else {
+                data.add(meta.getColumnName(i), mapColumn(i, rs));
+            }
+
         return data;
     }
 

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -184,6 +184,7 @@ public class DataMapper implements RowMapper<Object> {
 
     private opstillingskreds mapOpstillingskreds(ResultSet rs, StatementContext ctx) throws SQLException {
         opstillingskreds data = new opstillingskreds();
+        // Return strings as integers
         List<String> intColumns  = new ArrayList<String>(3);
         intColumns.add("opstillingskredsnummer");
         intColumns.add("valgkredsnummer");
@@ -202,6 +203,7 @@ public class DataMapper implements RowMapper<Object> {
     private politikreds mapPolitikreds(ResultSet rs, StatementContext ctx) throws SQLException {
         politikreds data = new politikreds();
 
+        // Return strings as integers
         List<String> intColumns  = new ArrayList<String>(1);
         intColumns.add("politikredsnummer");
 

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -135,7 +135,7 @@ public class DataMapper implements RowMapper<Object> {
                 data.add(meta.getColumnName(i), rs.getInt(i));
             }
             else if (meta.getColumnName(i).equals("centroid_x") || meta.getColumnName(i).equals("centroid_y")) {
-                data.add(meta.getColumnName(i), rs.getFloat(i));
+                data.add(meta.getColumnName(i), rs.getDouble(i));
             }
             else {
                 data.add(meta.getColumnName(i), mapColumn(i, rs));

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -124,30 +124,54 @@ public class DataMapper implements RowMapper<Object> {
 
     private matrikel mapMatrikel(ResultSet rs, StatementContext ctx) throws SQLException {
         matrikel data = new matrikel();
-        // Return strings as numbers
+        // Return strings as integers
         List<String> intColumns  = new ArrayList<String>(3);
         intColumns.add("ejerlavskode");
         intColumns.add("jordstykke_id");
         intColumns.add("bfenummer");
+        // Return strings as doubles
+        List<String> doubleColumns  = new ArrayList<String>(2);
+        doubleColumns.add("centroid_x");
+        doubleColumns.add("centroid_y");
 
-        for (int i = 1; i <= meta.getColumnCount(); i++)
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
             if (intColumns.contains(meta.getColumnName(i))) {
                 data.add(meta.getColumnName(i), rs.getInt(i));
             }
-            else if (meta.getColumnName(i).equals("centroid_x") || meta.getColumnName(i).equals("centroid_y")) {
+            else if (doubleColumns.contains(meta.getColumnName(i))) {
                 data.add(meta.getColumnName(i), rs.getDouble(i));
             }
             else {
                 data.add(meta.getColumnName(i), mapColumn(i, rs));
             }
-
+        }
         return data;
     }
 
     private matrikel_udgaaet mapMatrikelUdgaaet(ResultSet rs, StatementContext ctx) throws SQLException {
         matrikel_udgaaet data = new matrikel_udgaaet();
-        for (int i = 1; i <= meta.getColumnCount(); i++)
-            data.add(meta.getColumnName(i), mapColumn(i, rs));
+        // Return strings as integers
+        List<String> intColumns  = new ArrayList<String>(3);
+        intColumns.add("ejerlavskode");
+        intColumns.add("jordstykke_id");
+        intColumns.add("bfenummer");
+        // Return strings as doubles
+        List<String> doubleColumns  = new ArrayList<String>(2);
+        doubleColumns.add("centroid_x");
+        doubleColumns.add("centroid_y");
+
+
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            if (intColumns.contains(meta.getColumnName(i))) {
+                data.add(meta.getColumnName(i), rs.getInt(i));
+            }
+            else if (doubleColumns.contains(meta.getColumnName(i))) {
+                data.add(meta.getColumnName(i), rs.getDouble(i));
+            }
+            else {
+                data.add(meta.getColumnName(i), mapColumn(i, rs));
+            }
+        }
         return data;
     }
 
@@ -160,8 +184,17 @@ public class DataMapper implements RowMapper<Object> {
 
     private opstillingskreds mapOpstillingskreds(ResultSet rs, StatementContext ctx) throws SQLException {
         opstillingskreds data = new opstillingskreds();
+        List<String> intColumns  = new ArrayList<String>(3);
+        intColumns.add("opstillingskredsnummer");
+        intColumns.add("valgkredsnummer");
+        intColumns.add("storkredsnummer");
         for (int i = 1; i <= meta.getColumnCount(); i++)
-            data.add(meta.getColumnName(i), mapColumn(i, rs));
+            if (intColumns.contains(meta.getColumnName(i))) {
+                data.add(meta.getColumnName(i), rs.getInt(i));
+            }
+            else {
+                data.add(meta.getColumnName(i), mapColumn(i, rs));
+            }
         return data;
     }
 

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -188,20 +188,31 @@ public class DataMapper implements RowMapper<Object> {
         intColumns.add("opstillingskredsnummer");
         intColumns.add("valgkredsnummer");
         intColumns.add("storkredsnummer");
-        for (int i = 1; i <= meta.getColumnCount(); i++)
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
             if (intColumns.contains(meta.getColumnName(i))) {
                 data.add(meta.getColumnName(i), rs.getInt(i));
             }
             else {
                 data.add(meta.getColumnName(i), mapColumn(i, rs));
             }
+        }
         return data;
     }
 
     private politikreds mapPolitikreds(ResultSet rs, StatementContext ctx) throws SQLException {
         politikreds data = new politikreds();
-        for (int i = 1; i <= meta.getColumnCount(); i++)
-            data.add(meta.getColumnName(i), mapColumn(i, rs));
+
+        List<String> intColumns  = new ArrayList<String>(1);
+        intColumns.add("politikredsnummer");
+
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            if (intColumns.contains(meta.getColumnName(i))) {
+                data.add(meta.getColumnName(i), rs.getInt(i));
+            }
+            else {
+                data.add(meta.getColumnName(i), mapColumn(i, rs));
+            }
+        }
         return data;
     }
 

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -202,7 +202,6 @@ public class DataMapper implements RowMapper<Object> {
 
     private politikreds mapPolitikreds(ResultSet rs, StatementContext ctx) throws SQLException {
         politikreds data = new politikreds();
-
         // Return strings as integers
         List<String> intColumns  = new ArrayList<String>(1);
         intColumns.add("politikredsnummer");
@@ -234,8 +233,18 @@ public class DataMapper implements RowMapper<Object> {
 
     private retskreds mapRetskreds(ResultSet rs, StatementContext ctx) throws SQLException {
         retskreds data = new retskreds();
-        for (int i = 1; i <= meta.getColumnCount(); i++)
-            data.add(meta.getColumnName(i), mapColumn(i, rs));
+        // Return strings as integers
+        List<String> intColumns  = new ArrayList<String>(1);
+        intColumns.add("retskredsnummer");
+        
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            if (intColumns.contains(meta.getColumnName(i))) {
+                data.add(meta.getColumnName(i), rs.getInt(i));
+            }
+            else {
+                data.add(meta.getColumnName(i), mapColumn(i, rs));
+            }
+        }
         return data;
     }
 

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -22,6 +22,7 @@ import org.locationtech.jts.geom.Geometry;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.*;
 
 /**
  * Maps dynamic row data into the generic Data entity
@@ -124,7 +125,7 @@ public class DataMapper implements RowMapper<Object> {
     private matrikel mapMatrikel(ResultSet rs, StatementContext ctx) throws SQLException {
         matrikel data = new matrikel();
         // Return strings as numbers
-        List<String> intColumns  = new ArrayList<String>(4);
+        List<String> intColumns  = new ArrayList<String>(3);
         intColumns.add("ejerlavskode");
         intColumns.add("jordstykke_id");
         intColumns.add("bfenummer");
@@ -133,7 +134,7 @@ public class DataMapper implements RowMapper<Object> {
             if (intColumns.contains(meta.getColumnName(i))) {
                 data.add(meta.getColumnName(i), rs.getInt(i));
             }
-            else if (columnName.equals("centroid_x") || columnName.equals("centroid_y")) {
+            else if (meta.getColumnName(i).equals("centroid_x") || meta.getColumnName(i).equals("centroid_y")) {
                 data.add(meta.getColumnName(i), rs.getFloat(i));
             }
             else {

--- a/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
+++ b/src/main/java/dk/dataforsyningen/gsearch/mapper/DataMapper.java
@@ -22,7 +22,8 @@ import org.locationtech.jts.geom.Geometry;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Maps dynamic row data into the generic Data entity

--- a/src/test/resources/karate/matrikel.feature
+++ b/src/test/resources/karate/matrikel.feature
@@ -14,17 +14,17 @@ Feature: Gsearch matrikel test
         And match response contains only
         """
         {
-            "ejerlavskode": '#string',
+            "ejerlavskode": '#number',
             "ejerlavsnavn": '#string',
             "visningstekst": '#string',
             "geometri": '#(geometriSchema)',
-            "centroid_x": '#string',
-            "centroid_y": '#string',
+            "centroid_x": '#number',
+            "centroid_y": '#number',
             "matrikelnummer": '#string',
             "kommunenavn": "#string",
             "kommunekode": "#string",
-            "bfenummer": "#string",
-            "jordstykke_id": "#string"
+            "bfenummer": "#number",
+            "jordstykke_id": "#number"
         }
         """
 
@@ -134,3 +134,12 @@ Feature: Gsearch matrikel test
         When method GET
         Then status 200
         And match response == '#[100]'
+        
+    Scenario: Test string to double typecast of centroids
+        Then param q = '5787'
+
+        And param limit = '1'
+        When method GET
+        Then status 200
+        And match response.[*].centroid_x contains deep [723841.455]
+        And match response.[*].centroid_y contains deep [6179661.553]

--- a/src/test/resources/karate/matrikel_udgaaet.feature
+++ b/src/test/resources/karate/matrikel_udgaaet.feature
@@ -14,17 +14,17 @@ Feature: Gsearch matrikel test
         And match response contains only
         """
         {
-            "ejerlavskode": '#string',
+            "ejerlavskode": '#number',
             "ejerlavsnavn": '#string',
             "visningstekst": '#string',
             "geometri": '#(geometriSchema)',
-            "centroid_x": '#string',
-            "centroid_y": '#string',
+            "centroid_x": '#number',
+            "centroid_y": '#number',
             "matrikelnummer": '#string',
             "kommunenavn": "#string",
             "kommunekode": "#string",
-            "bfenummer": "#string",
-            "jordstykke_id": "#string"
+            "bfenummer": "#number",
+            "jordstykke_id": "#number"
         }
         """
 
@@ -134,3 +134,12 @@ Feature: Gsearch matrikel test
         When method GET
         Then status 200
         And match response == '#[100]'
+
+    Scenario: Test string to double typecast of centroids
+        Then param q = '401954 1bk'
+
+        And param limit = '1'
+        When method GET
+        Then status 200
+        And match response.[*].centroid_x contains deep [549053.048]
+        And match response.[*].centroid_y contains deep [6150995.375]

--- a/src/test/resources/karate/opstillingskreds.feature
+++ b/src/test/resources/karate/opstillingskreds.feature
@@ -17,11 +17,11 @@ Feature: Gsearch opstillingskreds test
       "opstillingskredsnavn": '#string',
       "visningstekst": '#string',
       "bbox": '#(bboxSchema)',
-      "valgkredsnummer": '#string',
+      "valgkredsnummer": '#number',
       "kommunekode": '#string',
       "geometri": '#(geometriSchema)',
-      "opstillingskredsnummer": '#string',
-      "storkredsnummer": '#string',
+      "opstillingskredsnummer": '#number',
+      "storkredsnummer": '#number',
       "storkredsnavn": '#string'
     }
     """

--- a/src/test/resources/karate/politikreds.feature
+++ b/src/test/resources/karate/politikreds.feature
@@ -16,7 +16,7 @@ Feature: Gsearch politikreds test
         {
             "visningstekst": '#string',
             "bbox": '#(bboxSchema)',
-            "politikredsnummer": '#string',
+            "politikredsnummer": '#number',
             "geometri": '#(geometriSchema)',
             "myndighedskode": '#string',
             "navn": "#string",

--- a/src/test/resources/karate/retskreds.feature
+++ b/src/test/resources/karate/retskreds.feature
@@ -19,7 +19,7 @@ Feature: Gsearch retskreds test
                 "retkredsnavn": '#string',
                 "kommunekode": '#string',
                 "geometri": '#(geometriSchema)',
-                "retskredsnummer": '#string',
+                "retskredsnummer": '#number',
                 "myndighedskode": '#string'
             }
         """


### PR DESCRIPTION
Following are now returned as integers

**opstillingskreds:**
  - opstillingskredsnummer
  - valgkredsnummer
  - storkredsnummer

**politikreds:**
  - politikredsnummer

**retskreds:**
  - retskredsnummer

**matrikel:**
  - ejerlavskode
  - jordstykke_id
  - bfenummer

**matrikel_udgaaet:**
  - ejerlavskode
  - jordstykke_id
  - bfenummer

Following are now returned as doubles

**matrikel:**
  - centroid_x
  - centroid_y

**matrikel_udgaaet:**
  - centroid_x
  - centroid_y

### **Note: Filters using these values must still be sent as strings**