### PR TITLE
V2.0.7

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -279,12 +279,12 @@ Syntaks eksempel som søger efter `bfenummer` '9738473' :
 <br/><br/>
 
 ```http
-GET https://api.dataforsyningen.dk/rest/gsearch/v2.0/matrikel?q=a&filter=bfenummer=%27100032397%27 HTTP/1.1
+GET https://api.dataforsyningen.dk/rest/gsearch/v2.0/matrikel?q=a&filter=bfenummer=%271406344%27 HTTP/1.1
 Host: api.dataforsyningen.dk
 Accept: application/json
 ```
 
-Syntaks eksempel som søger efter 'a' med `filter` på `bfenummer` '100032397':
+Syntaks eksempel som søger efter 'a' med `filter` på `bfenummer` '1406344':
 
 <br/><br/>
 
@@ -575,4 +575,3 @@ Accept: application/json
 Syntaks eksempel som søger efter 'steng' og med `filter` på `geometri` - Odsherred:
 
 <br/><br/>
-

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-cql</artifactId>
-            <version>33.1</version>
+            <version>33.2</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-wkt</artifactId>
-            <version>33.1</version>
+            <version>33.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.5</version>
+            <version>42.7.8</version>
         </dependency>
         <dependency>
             <groupId>org.n52.jackson</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.geotools.jdbc</groupId>
             <artifactId>gt-jdbc-postgis</artifactId>
-            <version>33.1</version>
+            <version>33.2</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.8</version>
+            <version>2.8.14</version>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.5.7</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <description>Gsearch</description>
     <properties>
         <java.version>21</java.version>
-        <org.jdbi.version>3.49.4</org.jdbi.version>
+        <org.jdbi.version>3.50.0</org.jdbi.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/test/resources/karate/documentation_examples.feature
+++ b/src/test/resources/karate/documentation_examples.feature
@@ -177,11 +177,11 @@ Feature:
 
 
     Scenario: matrikel example 4
-        # https://api.dataforsyningen.dk/rest/gsearch/v2.0/matrikel?q=a&filter=bfenummer='100032397'
+        # https://api.dataforsyningen.dk/rest/gsearch/v2.0/matrikel?q=a&filter=bfenummer='1406344'
         Given path 'matrikel'
         Then param q = 'a'
 
-        And param filter = "bfenummer='100032397'"
+        And param filter = "bfenummer='1406344'"
         When method GET
         Then status 200
         And match response == '#[10]'


### PR DESCRIPTION
Update Spring Boot and dependencies
- This includes Tomcat v10.1.48 and should mitigate CVE-2025-55752, CVE-2025-55754

Update docs and corresponding test to reflect change in `matrikel` data.